### PR TITLE
Make PagerDuty schedule lookahead configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ Multiple schedules can be synced at once by passing many env variables beginning
     
 Full parameter list:
 
-| Env Name              | Description                                | Default Value  | Example                 |
-|:----------------------|:-------------------------------------------|:---------------|:------------------------|
-| PAGERDUTY_TOKEN       | Token used to talk to the PagerDuty API    | n/a            | xxxxx                   | 
-| SLACK_TOKEN           | Token used to talk to Slack API            | n/a            | xoxp-xxxxxx             |
-| SCHEDULE_<NAME>       | A PagerDuty schedule that you want to sync | n/a            | 1234,platform-engineer  |
-| RUN_INTERVAL_SECONDS  | Run a sync every X seconds                 | 60             | 300                     |
+| Env Name                     | Description                                                                       | Default Value  | Example                 |
+|:-----------------------------|:----------------------------------------------------------------------------------|:---------------|:------------------------|
+| PAGERDUTY_TOKEN              | Token used to talk to the PagerDuty API                                           | n/a            | xxxxx                   |
+| SLACK_TOKEN                  | Token used to talk to Slack API                                                   | n/a            | xoxp-xxxxxx             |
+| SCHEDULE_<NAME>              | A PagerDuty schedule that you want to sync                                        | n/a            | 1234,platform-engineer  |
+| RUN_INTERVAL_SECONDS         | Run a sync every X seconds                                                        | 60             | 300                     |
+| PAGERDUTY_SCHEDULE_LOOKAHEAD | How far into the future to evaluate Pagerduty schedules (Go time duration format) | 2400h          | 8760h                   |
 
 
 ## Slack permissions

--- a/internal/sync/pagerduty.go
+++ b/internal/sync/pagerduty.go
@@ -1,8 +1,9 @@
 package sync
 
 import (
-	"github.com/PagerDuty/go-pagerduty"
 	"time"
+
+	"github.com/PagerDuty/go-pagerduty"
 )
 
 type pagerDutyClient struct {
@@ -15,10 +16,10 @@ func newPagerDutyClient(token string) *pagerDutyClient {
 	}
 }
 
-func (p *pagerDutyClient) getEmailsOfAllOnCallForSchedule(ID string) ([]string, error) {
+func (p *pagerDutyClient) getEmailsOfAllOnCallForSchedule(ID string, lookahead time.Duration) ([]string, error) {
 	users, err := p.client.ListOnCallUsers(ID, pagerduty.ListOnCallUsersOptions{
 		Since: time.Now().UTC().Format(time.RFC3339),
-		Until: time.Now().UTC().Add(time.Hour * 24 * 100).Format(time.RFC3339),
+		Until: time.Now().UTC().Add(lookahead).Format(time.RFC3339),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/sync/schedule_sync.go
+++ b/internal/sync/schedule_sync.go
@@ -1,9 +1,10 @@
 package sync
 
 import (
+	"strings"
+
 	"github.com/kevholditch/go-pagerduty-slack-sync/internal/compare"
 	"github.com/sirupsen/logrus"
-	"strings"
 )
 
 // Schedules does the sync
@@ -54,7 +55,7 @@ func Schedules(config *Config) error {
 		}
 
 		logrus.Infof("checking slack group: %s", schedule.AllOnCallGroupName)
-		emails, err = p.getEmailsOfAllOnCallForSchedule(schedule.ScheduleID)
+		emails, err = p.getEmailsOfAllOnCallForSchedule(schedule.ScheduleID, config.PagerdutyScheduleLookahead)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Some PD schedules might have a very long rotation time, e.g. half a year. Make the duration for which we evaluate PD schedules and consider people to be on-call configurable.

This change only affects the `all-oncall...` group.