### PR TITLE
Support for schedule groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,19 @@ The following slack groups would be created:
 Multiple schedules can be synced at once by passing many env variables beginning with `SCHEDULE_`.  The format for the value that the schedule parameter expects is `<pagerduty schedule id>/<group-name>`.  The `<group name>` will be used to build the two names for the slack groups using the following format:
     - `all-oncall-<group-name>s`
     - `current-oncall-<group-name>`
-    
+
+If there are multiple schedules with the same `<group-name>` are defined, then slack groups contains the combined list of all people for all the given schedules.
+
+For instance given following environment variables:
+```
+-e SCHEDULE_TEAM_1=abcd,platform-engineer -e SCHEDULE_TEAM_2=efgh,platform-engineer
+```
+
+This will result in a pair of slack groups with the combined users:
+- `@all-oncall-platform-engineers` => combined list of all users in `abcd` and `efgh` schedules
+- `@current-oncall-platform-engineer` => combined list of current on call users in `abcd` and `efgh` schedules
+
+
 Full parameter list:
 
 | Env Name                     | Description                                                                       | Default Value  | Example                 |

--- a/internal/sync/config.go
+++ b/internal/sync/config.go
@@ -29,13 +29,11 @@ type Config struct {
 }
 
 // Schedule models a PagerDuty schedule that will be synced with Slack
-// ScheduleID - PagerDuty schedule id to sync
+// ScheduleIDs - All PagerDuty schedule ID's to sync
 // AllOnCallGroupName - Slack group name for all members of schedule
-// ScheduleGroup - All PagerDuty schedule ID's to sync
 // CurrentOnCallGroupName - Slack group name for current person on call
 type Schedule struct {
-	ScheduleID             string
-	ScheduleGroup          []string
+	ScheduleIDs            []string
 	AllOnCallGroupName     string
 	CurrentOnCallGroupName string
 }
@@ -99,8 +97,7 @@ func appendSchedule(schedules []Schedule, scheduleID, teamName string) []Schedul
 		updated = true
 
 		newScheduleList[i] = Schedule{
-			ScheduleID:             "",
-			ScheduleGroup:          append(s.ScheduleGroup, scheduleID),
+			ScheduleIDs:            append(s.ScheduleIDs, scheduleID),
 			AllOnCallGroupName:     allGroupName,
 			CurrentOnCallGroupName: currentGroupName,
 		}
@@ -108,8 +105,7 @@ func appendSchedule(schedules []Schedule, scheduleID, teamName string) []Schedul
 
 	if !updated {
 		newScheduleList = append(newScheduleList, Schedule{
-			ScheduleID:             scheduleID,
-			ScheduleGroup:          []string{scheduleID},
+			ScheduleIDs:            []string{scheduleID},
 			AllOnCallGroupName:     allGroupName,
 			CurrentOnCallGroupName: currentGroupName,
 		})

--- a/internal/sync/config.go
+++ b/internal/sync/config.go
@@ -31,9 +31,11 @@ type Config struct {
 // Schedule models a PagerDuty schedule that will be synced with Slack
 // ScheduleID - PagerDuty schedule id to sync
 // AllOnCallGroupName - Slack group name for all members of schedule
+// ScheduleGroup - All PagerDuty schedule ID's to sync
 // CurrentOnCallGroupName - Slack group name for current person on call
 type Schedule struct {
 	ScheduleID             string
+	ScheduleGroup          []string
 	AllOnCallGroupName     string
 	CurrentOnCallGroupName string
 }

--- a/internal/sync/config_test.go
+++ b/internal/sync/config_test.go
@@ -28,6 +28,7 @@ func Test_NewConfigFromEnv_SingleScheduleDefined(t *testing.T) {
 
 	assert.True(t, assert.ObjectsAreEqualValues([]Schedule{{
 		ScheduleID:             "1234",
+		ScheduleGroup:          []string{"1234"},
 		AllOnCallGroupName:     "all-oncall-platform-engineers",
 		CurrentOnCallGroupName: "current-oncall-platform-engineer",
 	}},
@@ -52,6 +53,7 @@ func Test_NewConfigFromEnv_SingleScheduleDefinedWithDefaultRunInterval(t *testin
 
 	assert.True(t, assert.ObjectsAreEqualValues([]Schedule{{
 		ScheduleID:             "1234",
+		ScheduleGroup:          []string{"1234"},
 		AllOnCallGroupName:     "all-oncall-platform-engineers",
 		CurrentOnCallGroupName: "current-oncall-platform-engineer",
 	}},
@@ -78,6 +80,7 @@ func Test_NewConfigFromEnv_SingleScheduleDefinedWithScheduleLookahead(t *testing
 
 	assert.True(t, assert.ObjectsAreEqualValues([]Schedule{{
 		ScheduleID:             "1234",
+		ScheduleGroup:          []string{"1234"},
 		AllOnCallGroupName:     "all-oncall-platform-engineers",
 		CurrentOnCallGroupName: "current-oncall-platform-engineer",
 	}},
@@ -101,16 +104,19 @@ func Test_NewConfigFromEnv_MultipleScheduleDefined(t *testing.T) {
 	assert.True(t, assert.ObjectsAreEqualValues([]Schedule{
 		{
 			ScheduleID:             "1234",
+			ScheduleGroup:          []string{"1234"},
 			AllOnCallGroupName:     "all-oncall-platform-engineers",
 			CurrentOnCallGroupName: "current-oncall-platform-engineer",
 		},
 		{
 			ScheduleID:             "abcd",
+			ScheduleGroup:          []string{"abcd"},
 			AllOnCallGroupName:     "all-oncall-core-engineers",
 			CurrentOnCallGroupName: "current-oncall-core-engineer",
 		},
 		{
 			ScheduleID:             "efghass",
+			ScheduleGroup:          []string{"efghass"},
 			AllOnCallGroupName:     "all-oncall-uk-engineers",
 			CurrentOnCallGroupName: "current-oncall-uk-engineer",
 		},
@@ -130,13 +136,13 @@ func Test_NewConfigFromEnv_WithScheduleGroups(t *testing.T) {
 	assert.Equal(t, "token1", config.PagerDutyToken)
 	assert.Equal(t, "secretToken1", config.SlackToken)
 	assert.NoError(t, err)
-	assert.Equal(t, 3, len(config.Schedules))
+	assert.Equal(t, 1, len(config.Schedules))
 
 	assert.EqualValues(t, []Schedule{
 		{
 			ScheduleGroup:          []string{"aaaa", "bbbb", "cccc"},
-			AllOnCallGroupName:     "all-oncall-platform-engineers",
-			CurrentOnCallGroupName: "current-oncall-platform-engineer",
+			AllOnCallGroupName:     "all-oncall-core-engineers",
+			CurrentOnCallGroupName: "current-oncall-core-engineer",
 		},
 	},
 		config.Schedules)

--- a/internal/sync/config_test.go
+++ b/internal/sync/config_test.go
@@ -22,13 +22,11 @@ func Test_NewConfigFromEnv_SingleScheduleDefined(t *testing.T) {
 	assert.Equal(t, 10, config.RunIntervalInSeconds)
 	assert.Equal(t, time.Hour*24*100, config.PagerdutyScheduleLookahead)
 	assert.Equal(t, 1, len(config.Schedules))
-	assert.Equal(t, "1234", config.Schedules[0].ScheduleID)
 	assert.Equal(t, "all-oncall-platform-engineers", config.Schedules[0].AllOnCallGroupName)
 	assert.Equal(t, "current-oncall-platform-engineer", config.Schedules[0].CurrentOnCallGroupName)
 
 	assert.True(t, assert.ObjectsAreEqualValues([]Schedule{{
-		ScheduleID:             "1234",
-		ScheduleGroup:          []string{"1234"},
+		ScheduleIDs:            []string{"1234"},
 		AllOnCallGroupName:     "all-oncall-platform-engineers",
 		CurrentOnCallGroupName: "current-oncall-platform-engineer",
 	}},
@@ -47,13 +45,11 @@ func Test_NewConfigFromEnv_SingleScheduleDefinedWithDefaultRunInterval(t *testin
 	assert.Equal(t, "secretToken1", config.SlackToken)
 	assert.Equal(t, 60, config.RunIntervalInSeconds)
 	assert.Equal(t, 1, len(config.Schedules))
-	assert.Equal(t, "1234", config.Schedules[0].ScheduleID)
 	assert.Equal(t, "all-oncall-platform-engineers", config.Schedules[0].AllOnCallGroupName)
 	assert.Equal(t, "current-oncall-platform-engineer", config.Schedules[0].CurrentOnCallGroupName)
 
 	assert.True(t, assert.ObjectsAreEqualValues([]Schedule{{
-		ScheduleID:             "1234",
-		ScheduleGroup:          []string{"1234"},
+		ScheduleIDs:            []string{"1234"},
 		AllOnCallGroupName:     "all-oncall-platform-engineers",
 		CurrentOnCallGroupName: "current-oncall-platform-engineer",
 	}},
@@ -74,13 +70,11 @@ func Test_NewConfigFromEnv_SingleScheduleDefinedWithScheduleLookahead(t *testing
 	assert.Equal(t, 60, config.RunIntervalInSeconds)
 	assert.Equal(t, time.Hour*24*365, config.PagerdutyScheduleLookahead)
 	assert.Equal(t, 1, len(config.Schedules))
-	assert.Equal(t, "1234", config.Schedules[0].ScheduleID)
 	assert.Equal(t, "all-oncall-platform-engineers", config.Schedules[0].AllOnCallGroupName)
 	assert.Equal(t, "current-oncall-platform-engineer", config.Schedules[0].CurrentOnCallGroupName)
 
 	assert.True(t, assert.ObjectsAreEqualValues([]Schedule{{
-		ScheduleID:             "1234",
-		ScheduleGroup:          []string{"1234"},
+		ScheduleIDs:            []string{"1234"},
 		AllOnCallGroupName:     "all-oncall-platform-engineers",
 		CurrentOnCallGroupName: "current-oncall-platform-engineer",
 	}},
@@ -103,20 +97,17 @@ func Test_NewConfigFromEnv_MultipleScheduleDefined(t *testing.T) {
 
 	assert.True(t, assert.ObjectsAreEqualValues([]Schedule{
 		{
-			ScheduleID:             "1234",
-			ScheduleGroup:          []string{"1234"},
+			ScheduleIDs:            []string{"1234"},
 			AllOnCallGroupName:     "all-oncall-platform-engineers",
 			CurrentOnCallGroupName: "current-oncall-platform-engineer",
 		},
 		{
-			ScheduleID:             "abcd",
-			ScheduleGroup:          []string{"abcd"},
+			ScheduleIDs:            []string{"abcd"},
 			AllOnCallGroupName:     "all-oncall-core-engineers",
 			CurrentOnCallGroupName: "current-oncall-core-engineer",
 		},
 		{
-			ScheduleID:             "efghass",
-			ScheduleGroup:          []string{"efghass"},
+			ScheduleIDs:            []string{"efghass"},
 			AllOnCallGroupName:     "all-oncall-uk-engineers",
 			CurrentOnCallGroupName: "current-oncall-uk-engineer",
 		},
@@ -140,7 +131,7 @@ func Test_NewConfigFromEnv_WithScheduleGroups(t *testing.T) {
 
 	assert.EqualValues(t, []Schedule{
 		{
-			ScheduleGroup:          []string{"aaaa", "bbbb", "cccc"},
+			ScheduleIDs:            []string{"aaaa", "bbbb", "cccc"},
 			AllOnCallGroupName:     "all-oncall-core-engineers",
 			CurrentOnCallGroupName: "current-oncall-core-engineer",
 		},

--- a/internal/sync/config_test.go
+++ b/internal/sync/config_test.go
@@ -98,11 +98,12 @@ func Test_NewConfigFromEnv_MultipleScheduleDefined(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(config.Schedules))
 
-	assert.True(t, assert.ObjectsAreEqualValues([]Schedule{{
-		ScheduleID:             "1234",
-		AllOnCallGroupName:     "all-oncall-platform-engineers",
-		CurrentOnCallGroupName: "current-oncall-platform-engineer",
-	},
+	assert.True(t, assert.ObjectsAreEqualValues([]Schedule{
+		{
+			ScheduleID:             "1234",
+			AllOnCallGroupName:     "all-oncall-platform-engineers",
+			CurrentOnCallGroupName: "current-oncall-platform-engineer",
+		},
 		{
 			ScheduleID:             "abcd",
 			AllOnCallGroupName:     "all-oncall-core-engineers",
@@ -112,8 +113,33 @@ func Test_NewConfigFromEnv_MultipleScheduleDefined(t *testing.T) {
 			ScheduleID:             "efghass",
 			AllOnCallGroupName:     "all-oncall-uk-engineers",
 			CurrentOnCallGroupName: "current-oncall-uk-engineer",
-		}},
+		},
+	},
 		config.Schedules))
+}
+
+func Test_NewConfigFromEnv_WithScheduleGroups(t *testing.T) {
+	defer SetEnv("PAGERDUTY_TOKEN", "token1")()
+	defer SetEnv("SLACK_TOKEN", "secretToken1")()
+	defer SetEnv("SCHEDULE_CORE_1", "aaaa,core-engineer")()
+	defer SetEnv("SCHEDULE_CORE_2", "bbbb,core-engineer")()
+	defer SetEnv("SCHEDULE_CORE_3", "cccc,core-engineer")()
+
+	config, err := NewConfigFromEnv()
+
+	assert.Equal(t, "token1", config.PagerDutyToken)
+	assert.Equal(t, "secretToken1", config.SlackToken)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(config.Schedules))
+
+	assert.EqualValues(t, []Schedule{
+		{
+			ScheduleGroup:          []string{"aaaa", "bbbb", "cccc"},
+			AllOnCallGroupName:     "all-oncall-platform-engineers",
+			CurrentOnCallGroupName: "current-oncall-platform-engineer",
+		},
+	},
+		config.Schedules)
 }
 
 func Test_NewConfigFromEnv_NoSchedulesDefined(t *testing.T) {

--- a/internal/sync/pagerduty.go
+++ b/internal/sync/pagerduty.go
@@ -16,26 +16,10 @@ func newPagerDutyClient(token string) *pagerDutyClient {
 	}
 }
 
-func (p *pagerDutyClient) getEmailsOfAllOnCallForSchedule(ID string, lookahead time.Duration) ([]string, error) {
+func (p *pagerDutyClient) getEmailsForSchedule(ID string, lookahead time.Duration) ([]string, error) {
 	users, err := p.client.ListOnCallUsers(ID, pagerduty.ListOnCallUsersOptions{
 		Since: time.Now().UTC().Format(time.RFC3339),
 		Until: time.Now().UTC().Add(lookahead).Format(time.RFC3339),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	var results []string
-	for _, user := range users {
-		results = append(results, user.Email)
-	}
-	return results, nil
-}
-
-func (p *pagerDutyClient) getEmailsOfCurrentOnCallForSchedule(ID string) ([]string, error) {
-	users, err := p.client.ListOnCallUsers(ID, pagerduty.ListOnCallUsersOptions{
-		Since: time.Now().UTC().Format(time.RFC3339),
-		Until: time.Now().UTC().Add(time.Second).Format(time.RFC3339),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/sync/schedule_sync.go
+++ b/internal/sync/schedule_sync.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"strings"
+	"time"
 
 	"github.com/kevholditch/go-pagerduty-slack-sync/internal/compare"
 	"github.com/sirupsen/logrus"
@@ -41,30 +42,60 @@ func Schedules(config *Config) error {
 		return nil
 	}
 
+	getEmailsForSchedules := func(schedules []string, lookahead time.Duration) ([]string, error) {
+		var emails []string
+
+		for _, sid := range schedules {
+			e, err := p.getEmailsForSchedule(sid, lookahead)
+			if err != nil {
+				return nil, err
+			}
+
+			emails = appendIfMissing(emails, e...)
+		}
+
+		return emails, nil
+	}
+
 	for _, schedule := range config.Schedules {
 		logrus.Infof("checking slack group: %s", schedule.CurrentOnCallGroupName)
-		emails, err := p.getEmailsOfCurrentOnCallForSchedule(schedule.ScheduleID)
+
+		currentOncallEngineerEmails, err := getEmailsForSchedules(schedule.ScheduleGroup, time.Second)
 		if err != nil {
 			return err
 		}
 
-		err = updateSlackGroup(emails, schedule.CurrentOnCallGroupName)
+		err = updateSlackGroup(currentOncallEngineerEmails, schedule.CurrentOnCallGroupName)
 		if err != nil {
 			return err
 		}
 
 		logrus.Infof("checking slack group: %s", schedule.AllOnCallGroupName)
-		emails, err = p.getEmailsOfAllOnCallForSchedule(schedule.ScheduleID, config.PagerdutyScheduleLookahead)
+
+		allOncallEngineerEmails, err := getEmailsForSchedules(schedule.ScheduleGroup, config.PagerdutyScheduleLookahead)
 		if err != nil {
 			return err
 		}
 
-		err = updateSlackGroup(emails, schedule.AllOnCallGroupName)
+		err = updateSlackGroup(allOncallEngineerEmails, schedule.AllOnCallGroupName)
 		if err != nil {
 			return err
 		}
-
 	}
 
 	return nil
+}
+
+func appendIfMissing(slice []string, items ...string) []string {
+out:
+	for _, i := range items {
+		for _, ele := range slice {
+			if ele == i {
+				continue out
+			}
+		}
+		slice = append(slice, i)
+	}
+
+	return slice
 }

--- a/internal/sync/schedule_sync.go
+++ b/internal/sync/schedule_sync.go
@@ -9,7 +9,6 @@ import (
 
 // Schedules does the sync
 func Schedules(config *Config) error {
-
 	logrus.Infof("running schedule sync...")
 	s, err := newSlackClient(config.SlackToken)
 	if err != nil {
@@ -17,7 +16,7 @@ func Schedules(config *Config) error {
 	}
 	p := newPagerDutyClient(config.PagerDutyToken)
 
-	updateSchedule := func(emails []string, groupName string) error {
+	updateSlackGroup := func(emails []string, groupName string) error {
 		slackIDs, err := s.getSlackIDsFromEmails(emails)
 		if err != nil {
 			return err
@@ -49,7 +48,7 @@ func Schedules(config *Config) error {
 			return err
 		}
 
-		err = updateSchedule(emails, schedule.CurrentOnCallGroupName)
+		err = updateSlackGroup(emails, schedule.CurrentOnCallGroupName)
 		if err != nil {
 			return err
 		}
@@ -60,7 +59,7 @@ func Schedules(config *Config) error {
 			return err
 		}
 
-		err = updateSchedule(emails, schedule.AllOnCallGroupName)
+		err = updateSlackGroup(emails, schedule.AllOnCallGroupName)
 		if err != nil {
 			return err
 		}

--- a/internal/sync/schedule_sync.go
+++ b/internal/sync/schedule_sync.go
@@ -60,7 +60,7 @@ func Schedules(config *Config) error {
 	for _, schedule := range config.Schedules {
 		logrus.Infof("checking slack group: %s", schedule.CurrentOnCallGroupName)
 
-		currentOncallEngineerEmails, err := getEmailsForSchedules(schedule.ScheduleGroup, time.Second)
+		currentOncallEngineerEmails, err := getEmailsForSchedules(schedule.ScheduleIDs, time.Second)
 		if err != nil {
 			return err
 		}
@@ -72,7 +72,7 @@ func Schedules(config *Config) error {
 
 		logrus.Infof("checking slack group: %s", schedule.AllOnCallGroupName)
 
-		allOncallEngineerEmails, err := getEmailsForSchedules(schedule.ScheduleGroup, config.PagerdutyScheduleLookahead)
+		allOncallEngineerEmails, err := getEmailsForSchedules(schedule.ScheduleIDs, config.PagerdutyScheduleLookahead)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
If there are multiple schedules with the same `<group-name>` are defined, then slack groups contains the combined list of all people for all the given schedules.

For instance given following environment variables:
```
-e SCHEDULE_TEAM_1=abcd,platform-engineer -e SCHEDULE_TEAM_2=efgh,platform-engineer
```

This will result in a pair of slack groups with the combined users:
- `@all-oncall-platform-engineers` => combined list of all users in `abcd` and `efgh` schedules
- `@current-oncall-platform-engineer` => combined list of current on call users in `abcd` and `efgh` schedules

