### PR TITLE
fix: tolerate sync errors for individual schedules and proceed with others

### DIFF
--- a/internal/sync/schedule_sync.go
+++ b/internal/sync/schedule_sync.go
@@ -62,24 +62,28 @@ func Schedules(config *Config) error {
 
 		currentOncallEngineerEmails, err := getEmailsForSchedules(schedule.ScheduleIDs, time.Second)
 		if err != nil {
-			return err
+			logrus.Errorf("failed to get emails for %s: %v", schedule.CurrentOnCallGroupName, err)
+			continue
 		}
 
 		err = updateSlackGroup(currentOncallEngineerEmails, schedule.CurrentOnCallGroupName)
 		if err != nil {
-			return err
+			logrus.Errorf("failed to update slack group %s: %v", schedule.CurrentOnCallGroupName, err)
+			continue
 		}
 
 		logrus.Infof("checking slack group: %s", schedule.AllOnCallGroupName)
 
 		allOncallEngineerEmails, err := getEmailsForSchedules(schedule.ScheduleIDs, config.PagerdutyScheduleLookahead)
 		if err != nil {
-			return err
+			logrus.Errorf("failed to get emails for %s: %v", schedule.AllOnCallGroupName, err)
+			continue
 		}
 
 		err = updateSlackGroup(allOncallEngineerEmails, schedule.AllOnCallGroupName)
 		if err != nil {
-			return err
+			logrus.Errorf("failed to update slack group %s: %v", schedule.AllOnCallGroupName, err)
+			continue
 		}
 	}
 


### PR DESCRIPTION
This PR changes how sync errors for individual PD schedules are handled. Originally, in case of intermittent errors in Slack communication (for reasons, which are out of scope), the whole sync would stop, which would mean that schedules further down the were only going to be handled with `RunIntervalInSeconds` x `n` seconds delay (where `n` is the number of schedules which failed to sync). As failure in syncing of a specific schedule should not affect sync for other schedules in any way, it should be safe to (log and) ignore the error and proceed with the next schedule, rather than stopping the whole process altogether.

Fixes https://github.com/kevholditch/go-pagerduty-slack-sync/issues/6