### PR TITLE
feat: Add all-current-oncall-engineers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ This will result in a pair of slack groups with the combined users:
 - `@all-oncall-platform-engineers` => combined list of all users in `abcd` and `efgh` schedules
 - `@current-oncall-platform-engineer` => combined list of current on call users in `abcd` and `efgh` schedules
 
+A slack group will be created with all the current on call engineers of the company:
+- `@all-current-oncall-engineers`
 
 Full parameter list:
 

--- a/internal/sync/schedule_sync.go
+++ b/internal/sync/schedule_sync.go
@@ -8,6 +8,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	allCurrentOncallEngineersSlackGroup = "all-current-oncall-engineers"
+)
+
 // Schedules does the sync
 func Schedules(config *Config) error {
 	logrus.Infof("running schedule sync...")
@@ -57,6 +61,8 @@ func Schedules(config *Config) error {
 		return emails, nil
 	}
 
+	var allCurrentOncallEngineerEmails []string
+
 	for _, schedule := range config.Schedules {
 		logrus.Infof("checking slack group: %s", schedule.CurrentOnCallGroupName)
 
@@ -65,6 +71,7 @@ func Schedules(config *Config) error {
 			logrus.Errorf("failed to get emails for %s: %v", schedule.CurrentOnCallGroupName, err)
 			continue
 		}
+		allCurrentOncallEngineerEmails = appendIfMissing(allCurrentOncallEngineerEmails, currentOncallEngineerEmails...)
 
 		err = updateSlackGroup(currentOncallEngineerEmails, schedule.CurrentOnCallGroupName)
 		if err != nil {
@@ -85,6 +92,11 @@ func Schedules(config *Config) error {
 			logrus.Errorf("failed to update slack group %s: %v", schedule.AllOnCallGroupName, err)
 			continue
 		}
+	}
+
+	err = updateSlackGroup(allCurrentOncallEngineerEmails, allCurrentOncallEngineersSlackGroup)
+	if err != nil {
+		logrus.Errorf("failed to update slack group %s: %v", allCurrentOncallEngineersSlackGroup, err)
 	}
 
 	return nil


### PR DESCRIPTION
In order to alert all the engineers of a company we're adding a new slack group called:

all-current-oncall-engineers