### PR TITLE
update to use latest go and support multi platform docker images

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.15.x'
+          go-version: '1.21.x'
 
       - name: CI
         run: make ci
@@ -33,20 +33,19 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Get the version
         id: vars
         run: echo ::set-output name=tag::$(echo ${GITHUB_REF} | cut -d '/' -f3)
 
-      - name: Build the tagged Docker image
-        run: docker build . --file ./build/package/Dockerfile --tag kevholditch/pagerduty-slack-sync:${{steps.vars.outputs.tag}}
-
-      - name: Push the tagged Docker image
-        run: docker push  kevholditch/pagerduty-slack-sync:${{steps.vars.outputs.tag}}
-
-      - name: Tag latest
-        run: docker tag kevholditch/pagerduty-slack-sync:${{steps.vars.outputs.tag}} kevholditch/pagerduty-slack-sync:latest
-
-      - name: Push the latest Docker image
-        run: docker push kevholditch/pagerduty-slack-sync:latest
-
+      - name: Build and push the Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/package/Dockerfile
+          push: true
+          tags: kevholditch/pagerduty-slack-sync:${{steps.vars.outputs.tag}}, kevholditch/pagerduty-slack-sync:latest
+          platforms: linux/amd64,linux/arm64
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get the version
         id: vars
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF} | cut -d '/' -f3)
+        run: echo "tag=$(echo ${GITHUB_REF} | cut -d '/' -f3)" >> $GITHUB_OUTPUT
 
       - name: Build and push the Docker image
         uses: docker/build-push-action@v2

--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,10 @@ TAG ?= $$(git describe --tags)
 build:
 	@env GOMODULE111=on find ./cmd/* -maxdepth 1 -type d -exec go build "{}" \;
 
-install-lint:
-	@go get -u golang.org/x/lint/golint
-
-install-deps: install-lint
-
-lint:
-	@golint ./...
-
 vet:
 	@go vet -v ./...
 
-check: lint vet
+check: vet
 
 test:
 	@go test -v ./...
@@ -26,6 +18,6 @@ docker-build:
 docker-publish:
 	@docker login
 
-ci: install-deps build check test
+ci: build check test
 
-.PHONY: build install-deps install-lint lint vet check test
+.PHONY: build vet check test

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.21-buster as builder
+# Use the latest available Go 1.21 image
+FROM golang:1.21 as builder
 COPY . /go-pagerduty-slack-sync
 WORKDIR /go-pagerduty-slack-sync
 ENV GO111MODULE=on

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.15.4-buster as builder
+FROM golang:1.21-buster as builder
 COPY . /go-pagerduty-slack-sync
 WORKDIR /go-pagerduty-slack-sync
 ENV GO111MODULE=on
 RUN CGO_ENABLED=0 go build ./cmd/pagerduty-slack-sync/
 
 FROM gcr.io/distroless/base
-MAINTAINER <Kevin Holditch> kevholditch@hotmail.com
+LABEL maintainer="Kevin Holditch <kevholditch@hotmail.com>"
 WORKDIR /app
 COPY --from=builder /go-pagerduty-slack-sync/pagerduty-slack-sync /app
 CMD ["./pagerduty-slack-sync"]

--- a/cmd/pagerduty-slack-sync/main.go
+++ b/cmd/pagerduty-slack-sync/main.go
@@ -1,17 +1,19 @@
 package main
 
 import (
-	"github.com/kevholditch/go-pagerduty-slack-sync/internal/sync"
-	"github.com/sirupsen/logrus"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/kevholditch/go-pagerduty-slack-sync/internal/sync"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
 
-	stop := make(chan os.Signal)
+	// Make the stop channel buffered
+	stop := make(chan os.Signal, 1) // Buffer size of 1
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
 	config, err := sync.NewConfigFromEnv()
@@ -40,5 +42,4 @@ func main() {
 			}
 		}
 	}
-
 }

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,21 @@
 module github.com/kevholditch/go-pagerduty-slack-sync
 
-go 1.15
+go 1.21.5
 
 require (
 	github.com/PagerDuty/go-pagerduty v1.3.0
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/slack-go/slack v0.7.2
 	github.com/stretchr/testify v1.6.1
-	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20190422165155-953cdadca894 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ github.com/PagerDuty/go-pagerduty v1.3.0 h1:2vWajLxpmGeP8pmsyZ0MjFneHa8ASJrztJRS
 github.com/PagerDuty/go-pagerduty v1.3.0/go.mod h1:W5hSIIPrzSgAkNBDiuymWN5g9yQVzimL7BUBL44f3RY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -21,7 +20,6 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -38,9 +36,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
- update to use go `1.12.5` from go `1.15`
- update to support multi platform docker images