### PR TITLE
Disable unmanaged groups

### DIFF
--- a/internal/sync/config.go
+++ b/internal/sync/config.go
@@ -17,6 +17,9 @@ const (
 	runIntervalDefault     = 60
 )
 
+const CurrentOncallGroupPrefix = "current-oncall-"
+const AllOncallGroupPrefix = "all-oncall-"
+
 // Config is used to configure application
 // PagerDutyToken - token used to connect to pagerduty API
 // SlackToken - token used to connect to Slack API
@@ -82,8 +85,8 @@ func NewConfigFromEnv() (*Config, error) {
 }
 
 func appendSchedule(schedules []Schedule, scheduleID, teamName string) []Schedule {
-	currentGroupName := fmt.Sprintf("current-oncall-%s", teamName)
-	allGroupName := fmt.Sprintf("all-oncall-%ss", teamName)
+	currentGroupName := fmt.Sprintf("%s%s", CurrentOncallGroupPrefix, teamName)
+	allGroupName := fmt.Sprintf("%s%ss", AllOncallGroupPrefix, teamName)
 	newScheduleList := make([]Schedule, len(schedules))
 	updated := false
 

--- a/internal/sync/schedule_sync.go
+++ b/internal/sync/schedule_sync.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kevholditch/go-pagerduty-slack-sync/internal/compare"
 	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
 )
 
 // Schedules does the sync
@@ -57,6 +58,7 @@ func Schedules(config *Config) error {
 		return emails, nil
 	}
 
+	managedGroupNames := map[string]struct{}{}
 	for _, schedule := range config.Schedules {
 		logrus.Infof("checking slack group: %s", schedule.CurrentOnCallGroupName)
 
@@ -84,6 +86,26 @@ func Schedules(config *Config) error {
 		if err != nil {
 			logrus.Errorf("failed to update slack group %s: %v", schedule.AllOnCallGroupName, err)
 			continue
+		}
+
+		managedGroupNames[schedule.CurrentOnCallGroupName] = struct{}{}
+		managedGroupNames[schedule.AllOnCallGroupName] = struct{}{}
+	}
+
+	if len(managedGroupNames) == 0 {
+		return nil
+	}
+
+	currentGroups := []*slack.UserGroup{}
+	currentGroups = append(currentGroups, s.findUserGroupByPrefix(CurrentOncallGroupPrefix)...)
+	currentGroups = append(currentGroups, s.findUserGroupByPrefix(AllOncallGroupPrefix)...)
+	for _, g := range currentGroups {
+		if _, ok := managedGroupNames[g.Name]; !ok {
+			_, err := s.Client.DisableUserGroup(g.Name)
+			if err != nil {
+				logrus.Errorf("failed to disable unmanaged user group %s, %v", g.Name, err)
+				continue
+			}
 		}
 	}
 

--- a/internal/sync/slack.go
+++ b/internal/sync/slack.go
@@ -2,8 +2,9 @@ package sync
 
 import (
 	"fmt"
-	"github.com/slack-go/slack"
 	"strings"
+
+	"github.com/slack-go/slack"
 )
 
 type slackClient struct {
@@ -35,6 +36,9 @@ func newSlackClient(token string) (*slackClient, error) {
 func (s *slackClient) createOrGetUserGroup(name string) (*slack.UserGroup, error) {
 	group := s.findUserGroupByName(name)
 	if group != nil {
+		if !group.DateDelete.Time().IsZero() {
+			s.Client.EnableUserGroup(name)
+		}
 		return group, nil
 	}
 
@@ -77,4 +81,14 @@ func (s *slackClient) findUserGroupByName(name string) *slack.UserGroup {
 		}
 	}
 	return nil
+}
+
+func (s *slackClient) findUserGroupByPrefix(prefix string) []*slack.UserGroup {
+	res := []*slack.UserGroup{}
+	for _, g := range s.userGroups {
+		if strings.HasPrefix(g.Name, prefix) {
+			res = append(res, &g)
+		}
+	}
+	return res
 }


### PR DESCRIPTION
When pagerduty-slack-sync is initialized with a new set of groups, old groups no longer supported by the program should be disabled.